### PR TITLE
[em-processor#3]: Чтение моделей из kafka, флаг о получении в Redis, отправка в kafka (без обработки)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,129 @@
-# Сервис обработки данных (em-processor)
+# Сервис обработки событий (em-processor)
+
+Микросервис `em-processor` отвечает за получение объектов событий (`Event`) и упоминаний (`Mention`) из Kafka, временное хранение и группировку их по идентификатору батча (`batchId`) в Redis, выполнение предварительной обработки и последующую отправку обработанных данных в соответствующие топики Kafka для доставки в Elasticsearch.
+
+## Основной рабочий процесс
+
+1.  **Получение данных из Kafka:**
+    *   Сервис слушает два топика Kafka (`adapter-event` и `adapter-mention`), содержащие JSON-представления объектов `Event` и `Mention`.
+    *   Из заголовка каждого сообщения извлекается идентификатор `batchId`, который группирует пары файлов событий и упоминаний (например, `20250323151500`).
+
+2.  **Регистрация батча и временное хранение в Redis:**
+    *   При получении первого сообщения для нового `batchId`, сервис (`BatchStateService`) регистрирует его в Redis и запускает "временное окно" (настраивается, по умолчанию 60 секунд).
+    *   Полученные объекты `Event` и `Mention` сериализуются в JSON и сохраняются в Redis (`EventProcessingService`) с ключами, включающими `batchId`. Устанавливается TTL (время жизни) для этих ключей, немного превышающее временное окно, для автоматической очистки в случае сбоев.
+    *   Идентификаторы (`GlobalEventId` для событий, `GlobalEventId_MentionIdentifier` для упоминаний) также сохраняются в отдельные множества Redis для каждого `batchId`.
+
+3.  **Контроль временного окна:**
+    *   Планировщик (`BatchProcessingScheduler`) периодически проверяет (`BatchStateService.checkExpiredBatchWindows()`) активные батчи в Redis.
+    *   Если временное окно для `batchId` истекло, он помечается как "готовый к обработке" (перемещается из множества активных в множество готовых батчей).
+
+4.  **Обработка готовых батчей:**
+    *   Планировщик периодически запрашивает (`BatchStateService.getNextReadyBatch()`) готовый `batchId` из Redis.
+    *   Если найден готовый батч:
+        *   `EventProcessingService.processBatch()` извлекает все связанные с `batchId` события и упоминания из Redis.
+        *   Данные передаются в `BatchProcessor`, который выполняет предварительную обработку (на данный момент базовая фильтрация, но предназначен для будущей логики валидации, обогащения, анализа тональности и т.д.).
+        *   Возвращается объект `BatchData` с обработанными списками событий и упоминаний.
+
+5.  **Отправка обработанных данных в Kafka:**
+    *   `KafkaMessagePublisher` отправляет обработанные объекты в исходящие топики Kafka:
+        *   События (`Event`) => `processor-event` (ключ: `GlobalEventId`)
+        *   Упоминания (`Mention`) => `processor-mention` (ключ: `GlobalEventId_MentionIdentifier`)
+    *   Отправка выполняется асинхронно.
+
+6.  **Очистка состояния в Redis:**
+    *   После **успешной** отправки *всех* событий и упоминаний для данного `batchId` в Kafka, вызывается `RedisBatchCleaner.cleanupBatch()`.
+    *   Этот компонент полностью удаляет все данные (события, упоминания) и метаданные состояния (время старта, идентификаторы в множествах активных/готовых) для обработанного `batchId` из Redis.
+
+## Обработка ошибок
+
+*   **Ошибки Kafka (Consumer):** Используется стандартный `DefaultErrorHandler` для повторных попыток при временных сбоях.
+*   **Ошибки Redis:** Логируются. Проблемы с Redis могут привести к потере данных батча или некорректной обработке окна. TTL на ключах служит механизмом подстраховки для очистки.
+*   **Ошибки сериализации/десериализации:** Логируются. Некорректные данные могут быть пропущены.
+*   **Ошибки обработки (`BatchProcessor`):** Логируются. В текущей реализации при ошибке обработки возвращаются исходные данные батча.
+*   **Ошибки Kafka (Producer):** Логируются. Если отправка хотя бы одного сообщения завершилась ошибкой, очистка Redis для этого `batchId` **не производится**, что позволяет повторно обработать батч при следующем запуске (если данные еще не удалены по TTL).
+
+## Расширяемость
+
+*   **Логика обработки:** Компонент `BatchProcessor` является основной точкой расширения для добавления сложной бизнес-логики обработки данных перед отправкой в Elasticsearch (фильтрация, валидация, анализ тональности, агрегация и т.д.).
+
+## Диаграмма последовательности (клик на кнопку ⟷ развернет схему)
+
+```mermaid
+sequenceDiagram
+    participant InKafka as Входящие топики Kafka
+    participant Listener as KafkaMessageListener
+    participant BatchStateSvc as BatchStateService
+    participant EventProcSvc as EventProcessingService
+    participant Redis as Redis
+    participant Scheduler as BatchProcessingScheduler
+    participant BatchProcessor as BatchProcessor
+    participant Publisher as KafkaMessagePublisher
+    participant Cleaner as RedisBatchCleaner
+    participant OutKafka as Исходящие топики Kafka
+
+    %% Получение и сохранение данных
+    InKafka->>Listener: Сообщение Event/Mention + Заголовок BatchId
+    Listener->>BatchStateSvc: registerBatch(batchId)
+    opt Новый батч
+        BatchStateSvc->>Redis: Сохраняем время старта batch:start:<batchId> (с TTL)
+        BatchStateSvc->>Redis: Добавляем в активные: active:batches <batchId>
+    end
+    Listener->>EventProcSvc: storeEvent/storeMention(batchId, data)
+    EventProcSvc->>Redis: Сохраняем данные: data:<type>:<batchId>:<id> (JSON, с TTL)
+    EventProcSvc->>Redis: Добавляем ID в множество: batch:<type>s:<batchId> <id> (с TTL)
+
+    %% Проверка и обработка окна
+    loop Периодически (напр., каждые 5 сек)
+        Scheduler->>BatchStateSvc: checkExpiredBatchWindows()
+        BatchStateSvc->>Redis: Получаем ID активных батчей: active:batches
+        BatchStateSvc->>Redis: Получаем время старта batch:start:<batchId> для каждого активного
+        opt Окно истекло для batchId
+            BatchStateSvc->>Redis: Добавляем в готовые: ready:batches <batchId>
+            BatchStateSvc->>Redis: Удаляем из активных: active:batches <batchId>
+        end
+    end
+
+    %% Обработка готового батча
+    loop Периодически (напр., каждые 3 сек)
+        Scheduler->>BatchStateSvc: getNextReadyBatch()
+        BatchStateSvc->>Redis: Извлекаем ID из готовых: ready:batches
+        BatchStateSvc-->>Scheduler: batchId (или null)
+
+        opt batchId получен
+            Scheduler->>EventProcSvc: processBatch(batchId)
+            EventProcSvc->>Redis: Получаем ID событий из множества: batch:events:<batchId>
+            EventProcSvc->>Redis: Получаем ID упоминаний из множества: batch:mentions:<batchId>
+            EventProcSvc->>Redis: Получаем данные событий по ID: data:event:<batchId>:<eventId>...
+            EventProcSvc->>Redis: Получаем данные упоминаний по ID: data:mention:<batchId>:<mentionId>...
+            EventProcSvc-->>EventProcSvc: Десериализация Event/Mention
+            EventProcSvc->>BatchProcessor: process(events, mentions)
+            BatchProcessor-->>EventProcSvc: Обработанные BatchData
+            EventProcSvc-->>Scheduler: Обработанные BatchData
+
+            %% Асинхронная отправка
+            par Отправка Событий
+                Scheduler->>Publisher: sendEvent(event, key) для каждого события
+                Publisher->>OutKafka: Event JSON в processor-event
+                OutKafka-->>Publisher: Подтверждение/Ошибка
+            and Отправка Упоминаний
+                Scheduler->>Publisher: sendMention(mention, key) для каждого упоминания
+                Publisher->>OutKafka: Mention JSON в processor-mention
+                OutKafka-->>Publisher: Подтверждение/Ошибка
+            end
+
+            %% Очистка после УСПЕШНОЙ отправки ВСЕХ сообщений
+            alt Все отправки в Kafka успешны
+                Scheduler->>Cleaner: cleanupBatch(batchId)
+                Cleaner->>Redis: Удаляем множество ID событий: batch:events:<batchId>
+                Cleaner->>Redis: Удаляем данные событий: data:event:<batchId>:*
+                Cleaner->>Redis: Удаляем множество ID упоминаний: batch:mentions:<batchId>
+                Cleaner->>Redis: Удаляем данные упоминаний: data:mention:<batchId>:*
+                Cleaner->>Redis: Удаляем время старта: batch:start:<batchId>
+                Cleaner->>Redis: Удаляем из активных: active:batches <batchId> (на всякий случай)
+                Cleaner->>Redis: Удаляем из готовых: ready:batches <batchId> (уже извлечен, но для надежности)
+            else Ошибка при отправке в Kafka
+                Scheduler->>Scheduler: Логируем ошибку, НЕ очищаем Redis
+            end
+        end
+    end
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
 	testImplementation(libs.testcontainers.junit)
 	testImplementation(libs.testcontainers.kafka)
 	testRuntimeOnly(libs.junit.platform.launcher)
+
+	// EM Library
+	implementation(libs.em.library.common)
 }
 
 dependencyManagement {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ lombok = "1.18.38"
 # Тестирование
 testcontainers = "1.20.6"
 
+# EM Library
+emLibraryCommon = "0.0.1-SNAPSHOT"
+
 [libraries]
 # Spring Boot
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
@@ -40,6 +43,9 @@ testcontainers-core = { module = "org.testcontainers:testcontainers", version.re
 testcontainers-junit = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+
+# EM Library
+em-library-common = { module = "com.neighbor.eventmosaic.library:em-library-common", version.ref = "emLibraryCommon" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,4 @@
 rootProject.name = "em-processor"
+
+// Относительный путь к общей либе
+includeBuild("../em-library-common")

--- a/src/main/java/com/neighbor/eventmosaic/processor/EmProcessorApplication.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/EmProcessorApplication.java
@@ -3,9 +3,11 @@ package com.neighbor.eventmosaic.processor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableScheduling
 public class EmProcessorApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/neighbor/eventmosaic/processor/component/BatchProcessor.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/component/BatchProcessor.java
@@ -1,0 +1,51 @@
+package com.neighbor.eventmosaic.processor.component;
+
+import com.neighbor.eventmosaic.library.common.dto.Event;
+import com.neighbor.eventmosaic.library.common.dto.Mention;
+import com.neighbor.eventmosaic.processor.dto.BatchData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchProcessor {
+
+    public BatchData process(List<Event> events,
+                             List<Mention> mentions) {
+
+        try {
+            // TODO: добавить логику обработки данных, например, фильтрация, агрегация и тд.
+
+            // Фильтрация событий (например только события с определённым условием)
+            List<Event> filteredEvents = events.stream()
+                    .filter(event -> event.getGlobalEventId() != null)
+                    .toList();
+
+            // Собираем ID оставшихся событий
+            Set<Long> validEventIds = filteredEvents.stream()
+                    .map(Event::getGlobalEventId)
+                    .collect(Collectors.toSet());
+
+            // Фильтрация упоминаний: только те, что ссылаются на оставшиеся события
+            List<Mention> filteredMentions = mentions.stream()
+                    .filter(mention -> validEventIds.contains(mention.getGlobalEventId()))
+                    .toList();
+
+            log.info("Обработка батча: {} событий, {} упоминаний после фильтрации",
+                    filteredEvents.size(), filteredMentions.size());
+
+            return new BatchData(filteredEvents, filteredMentions);
+
+        } catch (Exception e) {
+            log.error("Ошибка при обработке батча: {}", e.getMessage(), e);
+            // Возвращаем исходные данные, если что-то пошло не так
+            return new BatchData(events, mentions);
+        }
+    }
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/component/RedisBatchCleaner.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/component/RedisBatchCleaner.java
@@ -1,0 +1,73 @@
+package com.neighbor.eventmosaic.processor.component;
+
+import com.neighbor.eventmosaic.processor.util.RedisKeysUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * Класс для очистки Redis для указанного батча.
+ * Выполняет полную очистку данных и состояния для указанного батча в Redis.
+ * Удаляет данные по событиям, упоминаниям и состоянию.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisBatchCleaner {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * Выполняет полную очистку данных и состояния для указанного батча в Redis.
+     *
+     * @param batchId идентификатор батча
+     */
+    public void cleanupBatch(String batchId) {
+        log.info("Запуск полной очистки Redis для батча {}", batchId);
+        try {
+            // Удаление данных по событиям
+            cleanupDataSet(RedisKeysUtil.buildBatchEventsSetKey(batchId),
+                    id -> RedisKeysUtil.buildEventKey(batchId, Long.valueOf(id)));
+
+            // Удаление данных по упоминаниям
+            cleanupDataSet(RedisKeysUtil.buildBatchMentionsSetKey(batchId),
+                    id -> RedisKeysUtil.buildMentionKey(batchId, id));
+
+            // Удаление состояния
+            redisTemplate.opsForSet().remove(RedisKeysUtil.readyBatchesSetKey(), batchId);  // Из готовых
+            redisTemplate.opsForSet().remove(RedisKeysUtil.activeBatchesSetKey(), batchId); // Из активных (на всякий случай)
+            redisTemplate.delete(RedisKeysUtil.buildStartTimeKey(batchId));                 // Время старта
+
+            log.info("Полная очистка Redis для батча {} успешно завершена", batchId);
+
+        } catch (Exception e) {
+            log.error("Ошибка во время полной очистки Redis для батча {}: {}", batchId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Метод для удаления множества ключей данных.
+     * Сначала получает все ID из множества, затем удаляет ключи данных и само множество.
+     */
+    private void cleanupDataSet(String setKey,
+                                UnaryOperator<String> keyResolver) {
+
+        Set<String> ids = redisTemplate.opsForSet().members(setKey);
+
+        if (ids != null && !ids.isEmpty()) {
+            List<String> dataKeys = ids.stream()
+                    .map(keyResolver)
+                    .toList();
+
+            Long deletedCount = redisTemplate.delete(dataKeys);
+            log.debug("Удалено {} ключей данных для множества {}", deletedCount, setKey);
+        }
+        redisTemplate.delete(setKey);
+        log.debug("Удалено множество ключей {}", setKey);
+    }
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/dto/BatchData.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/dto/BatchData.java
@@ -1,0 +1,19 @@
+package com.neighbor.eventmosaic.processor.dto;
+
+import com.neighbor.eventmosaic.library.common.dto.Event;
+import com.neighbor.eventmosaic.library.common.dto.Mention;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Класс для хранения данных батча.
+ * Содержит список событий и упоминаний.
+ */
+@Data
+@AllArgsConstructor
+public class BatchData {
+    private List<Event> events;
+    private List<Mention> mentions;
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/listener/KafkaMessageListener.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/listener/KafkaMessageListener.java
@@ -1,0 +1,74 @@
+package com.neighbor.eventmosaic.processor.listener;
+
+import com.neighbor.eventmosaic.library.common.dto.Event;
+import com.neighbor.eventmosaic.library.common.dto.Mention;
+import com.neighbor.eventmosaic.processor.service.BatchStateService;
+import com.neighbor.eventmosaic.processor.service.EventProcessingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * Сервис для приема и обработки сообщений из Kafka.
+ * Сохраняет события и упоминания в Redis в рамках временного окна.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageListener {
+
+    private static final String BATCH_HEADER = "X-Batch-ID";
+
+    private final BatchStateService batchStateService;
+    private final EventProcessingService eventProcessingService;
+
+    /**
+     * Обрабатывает сообщения с событиями из входного топика.
+     * Сохраняет полученное событие и регистрирует батч если нужно.
+     *
+     * @param event   событие из сообщения
+     * @param batchId идентификатор батча из заголовка
+     */
+    @KafkaListener(
+            topics = "${kafka.topic.consumer.adapter-event}")
+    public void consumeEvent(@Payload Event event,
+                             @Header(value = BATCH_HEADER) String batchId) {
+
+        handleBatchRegistration(batchId);
+        log.debug("Получено событие с ID {} из батча {}", event.getGlobalEventId(), batchId);
+        eventProcessingService.storeEvent(batchId, event);
+    }
+
+    /**
+     * Обрабатывает сообщения с упоминаниями из входного топика.
+     * Сохраняет полученное упоминание и регистрирует батч если нужно.
+     *
+     * @param mention упоминание из сообщения
+     * @param batchId идентификатор батча из заголовка
+     */
+    @KafkaListener(
+            topics = "${kafka.topic.consumer.adapter-mention}")
+    public void consumeMention(@Payload Mention mention,
+                               @Header(value = BATCH_HEADER) String batchId) {
+
+        handleBatchRegistration(batchId);
+        log.debug("Получено упоминание для события с ID {} из батча {}",
+                mention.getGlobalEventId(), batchId);
+        eventProcessingService.storeMention(batchId, mention);
+    }
+
+    /**
+     * Общая логика регистрации батча и логгирования начала временного окна.
+     *
+     * @param batchId идентификатор батча
+     */
+    private void handleBatchRegistration(String batchId) {
+        boolean isNewBatch = batchStateService.registerBatch(batchId);
+        if (isNewBatch) {
+            log.info("Начато временное окно для нового батча: {}", batchId);
+        }
+    }
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/publisher/KafkaMessagePublisher.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/publisher/KafkaMessagePublisher.java
@@ -1,0 +1,80 @@
+package com.neighbor.eventmosaic.processor.publisher;
+
+import com.neighbor.eventmosaic.library.common.dto.Event;
+import com.neighbor.eventmosaic.library.common.dto.Mention;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Компонент для отправки обработанных событий и упоминаний в топики Kafka.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaMessagePublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${kafka.topic.producer.processor-event}")
+    private String eventTopic;
+
+    @Value("${kafka.topic.producer.processor-mention}")
+    private String mentionTopic;
+
+    /**
+     * Отправляет обработанное событие в соответствующий топик Kafka.
+     * После отправки проверяется, была ли отправка успешной.
+     *
+     * @param event объект события для отправки
+     * @param key   ключ сообщения (идентификатор события)
+     * @return CompletableFuture с результатом отправки
+     */
+    public CompletableFuture<SendResult<String, Object>> sendEvent(Event event, String key) {
+        log.debug("Отправка события с ID {} в топик {}", event.getGlobalEventId(), eventTopic);
+
+        return kafkaTemplate.send(eventTopic, key, event)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        log.debug("Событие с ID {} успешно отправлено, смещение: {}",
+                                event.getGlobalEventId(),
+                                result.getRecordMetadata().offset());
+                    } else {
+                        log.error("Ошибка при отправке события с ID {}: {}",
+                                event.getGlobalEventId(),
+                                ex.getMessage(), ex);
+                    }
+                });
+    }
+
+    /**
+     * Отправляет обработанное упоминание в соответствующий топик Kafka.
+     * После отправки проверяется, была ли отправка успешной.
+     *
+     * @param mention объект упоминания для отправки
+     * @param key     ключ сообщения (комбинация идентификаторов события и упоминания)
+     * @return CompletableFuture с результатом отправки
+     */
+    public CompletableFuture<SendResult<String, Object>> sendMention(Mention mention, String key) {
+        log.debug("Отправка упоминания для события с ID {} в топик {}",
+                mention.getGlobalEventId(), mentionTopic);
+
+        return kafkaTemplate.send(mentionTopic, key, mention)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        log.debug("Упоминание для события с ID {} успешно отправлено, смещение: {}",
+                                mention.getGlobalEventId(),
+                                result.getRecordMetadata().offset());
+                    } else {
+                        log.error("Ошибка при отправке упоминания для события с ID {}: {}",
+                                mention.getGlobalEventId(),
+                                ex.getMessage(), ex);
+                    }
+                });
+    }
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/scheduler/BatchProcessingScheduler.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/scheduler/BatchProcessingScheduler.java
@@ -1,0 +1,119 @@
+package com.neighbor.eventmosaic.processor.scheduler;
+
+import com.neighbor.eventmosaic.processor.dto.BatchData;
+import com.neighbor.eventmosaic.processor.service.BatchStateService;
+import com.neighbor.eventmosaic.processor.service.EventProcessingService;
+import com.neighbor.eventmosaic.processor.publisher.KafkaMessagePublisher;
+import com.neighbor.eventmosaic.processor.component.RedisBatchCleaner;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Планировщик для периодической проверки и обработки батчей.
+ * <p>
+ * Основные задачи:
+ * 1. Проверяет, истекло ли окно ожидания у активных батчей.
+ * 2. Если батч готов — извлекает его, обрабатывает события и упоминания.
+ * 3. Отправляет данные в Kafka и после успешной отправки очищает состояние.
+ * <p>
+ * Сейчас считаем, что в каждый момент времени активен только один батч.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchProcessingScheduler {
+
+    private final BatchStateService batchStateService;
+    private final EventProcessingService eventProcessingService;
+    private final KafkaMessagePublisher kafkaMessagePublisher;
+    private final RedisBatchCleaner redisBatchCleaner;
+
+    /**
+     * Проверяет, истекло ли время окна ожидания у активных батчей.
+     * Если да — помечает такие батчи как готовые к обработке.
+     * Запускается каждые 5 секунд.
+     */
+    @Scheduled(fixedDelayString = "5000")
+    public void checkBatchWindows() {
+        int expiredBatchCount = batchStateService.checkExpiredBatchWindows();
+        if (expiredBatchCount > 0) {
+            log.info("Обнаружено батчей с истекшим временем окна - {}", expiredBatchCount);
+        }
+    }
+
+    /**
+     * Обрабатывает один готовый к отправке батч.
+     * Получает данные, отправляет их в Kafka, очищает состояние после успешной отправки.
+     * Запускается каждые 3 секунды.
+     */
+    @Scheduled(fixedDelayString = "3000")
+    public void processBatchIfReady() {
+        String batchId = batchStateService.getNextReadyBatch();
+
+        if (batchId == null) {
+            log.debug("Нет готовых батчей для обработки");
+            return; // Нет батчей для обработки
+        }
+
+        try {
+            log.info("Начало обработки батча: {}", batchId);
+
+            BatchData batchData = eventProcessingService.processBatch(batchId);
+
+            CompletableFuture<Void> sendEventsFuture = sendEvents(batchData);
+            CompletableFuture<Void> sendMentionsFuture = sendMentions(batchData);
+
+            // Ждём завершения всех отправок и обрабатываем результат
+            CompletableFuture.allOf(sendEventsFuture, sendMentionsFuture)
+                    .whenComplete((ignored, ex) -> {
+                        if (ex == null) {
+                            log.info("Батч {} успешно обработан и отправлен", batchId);
+                            redisBatchCleaner.cleanupBatch(batchId);
+                        } else {
+                            log.error("Ошибка при отправке данных для батча {}: {}", batchId, ex.getMessage(), ex);
+                        }
+                    });
+
+        } catch (Exception e) {
+            log.error("Ошибка при обработке батча {}: {}", batchId, e.getMessage(), e);
+            // cleanupBatch не вызываем, если была ошибка обработки
+
+        }
+    }
+
+    /**
+     * Отправляет все события батча в Kafka.
+     * Вид ключа: globalEventId
+     *
+     * @param batchData объект с событиями и упоминаниями
+     * @return CompletableFuture, который завершится после отправки всех событий
+     */
+    private CompletableFuture<Void> sendEvents(BatchData batchData) {
+
+        return CompletableFuture.allOf(batchData.getEvents().stream()
+                .map(event -> kafkaMessagePublisher.sendEvent(
+                        event,
+                        String.valueOf(event.getGlobalEventId())))
+                .toArray(CompletableFuture[]::new));
+    }
+
+    /**
+     * Отправляет все упоминания батча в Kafka.
+     * Вид ключа: globalEventId_mentionIdentifier
+     *
+     * @param batchData объект с событиями и упоминаниями
+     * @return CompletableFuture, который завершится после отправки всех упоминаний
+     */
+    private CompletableFuture<Void> sendMentions(BatchData batchData) {
+
+        return CompletableFuture.allOf(batchData.getMentions().stream()
+                .map(mention -> kafkaMessagePublisher.sendMention(
+                        mention,
+                        mention.getGlobalEventId() + "_" + mention.getMentionIdentifier()))
+                .toArray(CompletableFuture[]::new));
+    }
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/service/BatchStateService.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/service/BatchStateService.java
@@ -1,0 +1,23 @@
+package com.neighbor.eventmosaic.processor.service;
+
+
+/**
+ * Интерфейс сервиса для управления состоянием обработки батчей (пакетов) данных.
+ */
+public interface BatchStateService {
+
+    /**
+     * Регистрирует новый батч или обновляет существующий.
+     */
+    boolean registerBatch(String batchId);
+
+    /**
+     * Проверяет батчи, время ожидания которых истекло, и помечает их как готовые к обработке.
+     */
+    int checkExpiredBatchWindows();
+
+    /**
+     * Получает и удаляет один готовый для обработки батч из списка.
+     */
+    String getNextReadyBatch();
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/service/EventProcessingService.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/service/EventProcessingService.java
@@ -1,0 +1,26 @@
+package com.neighbor.eventmosaic.processor.service;
+
+import com.neighbor.eventmosaic.library.common.dto.Event;
+import com.neighbor.eventmosaic.library.common.dto.Mention;
+import com.neighbor.eventmosaic.processor.dto.BatchData;
+
+/**
+ * Интерфейс сервиса для хранения и предварительной обработки событий и упоминаний.
+ */
+public interface EventProcessingService {
+
+    /**
+     * Сохраняет событие в Redis для последующей обработки.
+     */
+    void storeEvent(String batchId, Event event);
+
+    /**
+     * Сохраняет упоминание в Redis для последующей обработки.
+     */
+    void storeMention(String batchId, Mention mention);
+
+    /**
+     * Обрабатывает данные конкретного батча.
+     */
+    BatchData processBatch(String batchId);
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/service/impl/BatchStateServiceImpl.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/service/impl/BatchStateServiceImpl.java
@@ -1,0 +1,112 @@
+package com.neighbor.eventmosaic.processor.service.impl;
+
+import com.neighbor.eventmosaic.processor.service.BatchStateService;
+import com.neighbor.eventmosaic.processor.util.RedisKeysUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Set;
+
+/**
+ * Сервис для управления состоянием обработки батчей (пакетов) данных.
+ * Использует Redis для отслеживания и обработки батчей в рамках временного окна.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BatchStateServiceImpl implements BatchStateService {
+
+    private static final long EXTRA_TTL_MILLIS = 10_000;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${batch.processing.window-duration-ms:60000}")
+    private long batchWindowDurationMs;
+
+    /**
+     * Регистрирует новый батч или обновляет существующий.
+     * Если это первый раз, когда встречается батч, начинает отсчет времени окна.
+     *
+     * @param batchId идентификатор батча
+     * @return true если это новый батч, false если обновление существующего
+     */
+    @Override
+    public boolean registerBatch(String batchId) {
+        String startTimeKey = RedisKeysUtil.buildStartTimeKey(batchId);
+        boolean isNewBatch = !redisTemplate.hasKey(startTimeKey);
+
+        if (isNewBatch) {
+            long currentTime = System.currentTimeMillis();
+            redisTemplate.opsForValue().set(startTimeKey, String.valueOf(currentTime));
+            redisTemplate.expire(startTimeKey, getEffectiveTtl());
+
+            redisTemplate.opsForSet().add(RedisKeysUtil.activeBatchesSetKey(), batchId);
+
+            log.info("Зарегистрирован новый батч: {}. Установлено временное окно: {} мс",
+                    batchId, batchWindowDurationMs);
+        }
+
+        return isNewBatch;
+    }
+
+    /**
+     * Проверяет батчи, время ожидания которых истекло, и помечает их как готовые к обработке.
+     * Этот метод должен вызываться планировщиком.
+     *
+     * @return количество батчей, помеченных как готовые
+     */
+    @Override
+    public int checkExpiredBatchWindows() {
+        Set<String> activeBatches = redisTemplate.opsForSet().members(RedisKeysUtil.activeBatchesSetKey());
+        if (activeBatches == null || activeBatches.isEmpty()) {
+            return 0;
+        }
+
+        int processedCount = 0;
+        long now = System.currentTimeMillis();
+
+        for (String batchId : activeBatches) {
+            String startTimeStr = redisTemplate.opsForValue().get(RedisKeysUtil.buildStartTimeKey(batchId));
+
+            if (startTimeStr == null) {
+                redisTemplate.opsForSet().remove(RedisKeysUtil.activeBatchesSetKey(), batchId);
+                log.warn("Батч {} найден в активных, но без метки времени начала", batchId);
+                continue;
+            }
+
+            long startTime = Long.parseLong(startTimeStr);
+            if (now - startTime >= batchWindowDurationMs) {
+                redisTemplate.opsForSet().add(RedisKeysUtil.readyBatchesSetKey(), batchId);     // Помечаем как готовый
+                redisTemplate.opsForSet().remove(RedisKeysUtil.activeBatchesSetKey(), batchId); // Удаляем из активных
+
+                log.info("Батч {} готов к обработке после истечения времени окна ({} мс)", batchId, now - startTime);
+                processedCount++;
+            }
+        }
+        return processedCount;
+    }
+
+    /**
+     * Получает и удаляет один готовый для обработки батч из списка.
+     *
+     * @return идентификатор батча или null, если нет готовых батчей
+     */
+    @Override
+    public String getNextReadyBatch() {
+        return redisTemplate.opsForSet()
+                .pop(RedisKeysUtil.readyBatchesSetKey());
+    }
+
+
+    /**
+     * Возвращает итоговый TTL для ключей Redis.
+     * Включает время окна обработки и дополнительное время.
+     */
+    private Duration getEffectiveTtl() {
+        return Duration.ofMillis(batchWindowDurationMs + EXTRA_TTL_MILLIS);
+    }
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/service/impl/EventProcessingServiceImpl.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/service/impl/EventProcessingServiceImpl.java
@@ -1,0 +1,189 @@
+package com.neighbor.eventmosaic.processor.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.neighbor.eventmosaic.library.common.dto.Event;
+import com.neighbor.eventmosaic.library.common.dto.Mention;
+import com.neighbor.eventmosaic.processor.component.BatchProcessor;
+import com.neighbor.eventmosaic.processor.dto.BatchData;
+import com.neighbor.eventmosaic.processor.service.EventProcessingService;
+import com.neighbor.eventmosaic.processor.util.RedisKeysUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * Сервис для хранения и предварительной обработки событий и упоминаний.
+ * Временно хранит данные в Redis до истечения временного окна батча.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventProcessingServiceImpl implements EventProcessingService {
+
+    private static final long EXTRA_TTL_MILLIS = 10_000;
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final BatchProcessor batchProcessor;
+
+    @Value("${batch.processing.window-duration-ms:60000}")
+    private long batchWindowDurationMs;
+
+    /**
+     * Сохраняет событие в Redis для последующей обработки.
+     * Устанавливает TTL для ключей, чтобы они автоматически удалялись.
+     *
+     * @param batchId идентификатор батча
+     * @param event   событие для сохранения
+     */
+    @Override
+    public void storeEvent(String batchId, Event event) {
+        Long eventId = event.getGlobalEventId();
+        String eventKey = RedisKeysUtil.buildEventKey(batchId, eventId);
+
+        saveToRedis(eventKey, event);
+
+        String setKey = RedisKeysUtil.buildBatchEventsSetKey(batchId);
+        redisTemplate.opsForSet().add(setKey, eventId.toString());
+        redisTemplate.expire(setKey, getEffectiveTtl());
+
+        log.debug("Сохранено событие с ID {} для батча {} в Redis", eventId, batchId);
+    }
+
+    /**
+     * Сохраняет упоминание в Redis для последующей обработки.
+     * Устанавливает TTL для ключей, чтобы они автоматически удалялись.
+     *
+     * @param batchId идентификатор батча
+     * @param mention упоминание для сохранения
+     */
+    @Override
+    public void storeMention(String batchId, Mention mention) {
+        String mentionId = mention.getGlobalEventId() + "_" + mention.getMentionIdentifier();
+        String mentionKey = RedisKeysUtil.buildMentionKey(batchId, mentionId);
+
+        saveToRedis(mentionKey, mention);
+
+        String setKey = RedisKeysUtil.buildBatchMentionsSetKey(batchId);
+        redisTemplate.opsForSet().add(setKey, mentionId);
+        redisTemplate.expire(setKey, getEffectiveTtl());
+
+        log.debug("Сохранено упоминание с ID {} для батча {} в Redis", mentionId, batchId);
+    }
+
+    /**
+     * Обрабатывает данные конкретного батча.
+     * Выполняет предварительную обработку событий и упоминаний.
+     * В случае ошибки возвращает оригинальные данные.
+     * Пока возвращает список событий и упоминаний без изменений.
+     *
+     * @param batchId идентификатор батча
+     * @return объект BatchData
+     */
+    @Override
+    public BatchData processBatch(String batchId) {
+        log.info("Начало обработки данных батча {}", batchId);
+
+        List<Event> events = getEventsForBatch(batchId);
+        List<Mention> mentions = getMentionsForBatch(batchId);
+
+        log.info("Батч {} содержит {} событий и {} упоминаний", batchId, events.size(), mentions.size());
+
+        BatchData processed = batchProcessor.process(events, mentions);
+
+        return new BatchData(processed.getEvents(), processed.getMentions());
+    }
+
+    /**
+     * Возвращает все события для указанного батча из Redis.
+     *
+     * @param batchId идентификатор батча
+     * @return список событий или пустой список
+     */
+    private List<Event> getEventsForBatch(String batchId) {
+        return loadBatchData(
+                RedisKeysUtil.buildBatchEventsSetKey(batchId),
+                id -> RedisKeysUtil.buildEventKey(batchId, Long.valueOf(id)),
+                Event.class
+        );
+    }
+
+    /**
+     * Возвращает все упоминания для указанного батча из Redis.
+     *
+     * @param batchId идентификатор батча
+     * @return список упоминаний или пустой список
+     */
+    private List<Mention> getMentionsForBatch(String batchId) {
+        return loadBatchData(
+                RedisKeysUtil.buildBatchMentionsSetKey(batchId),
+                id -> RedisKeysUtil.buildMentionKey(batchId, id),
+                Mention.class
+        );
+    }
+
+
+    /**
+     * Сохраняет сериализованный объект в Redis с TTL.
+     */
+    private <T> void saveToRedis(String key, T object) {
+        try {
+            String json = objectMapper.writeValueAsString(object);
+            redisTemplate.opsForValue().set(key, json);
+            redisTemplate.expire(key, getEffectiveTtl());
+        } catch (JsonProcessingException e) {
+            log.error("Ошибка сериализации объекта {}: {}", object, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Загружает данные батча из Redis по ключам ID и преобразует в список объектов.
+     *
+     * @param setKey      ключ множества ID
+     * @param keyResolver функция преобразования ID в ключ Redis
+     * @param clazz       класс объекта для десериализации
+     * @return список объектов
+     */
+    private <T> List<T> loadBatchData(String setKey,
+                                      UnaryOperator<String> keyResolver,
+                                      Class<T> clazz) {
+
+        Set<String> ids = redisTemplate.opsForSet().members(setKey);
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return ids.stream()
+                .map(id -> {
+                    String json = redisTemplate.opsForValue().get(keyResolver.apply(id));
+                    if (json == null) {
+                        return null;
+                    }
+                    try {
+                        return objectMapper.readValue(json, clazz);
+                    } catch (JsonProcessingException e) {
+                        log.error("Ошибка десериализации объекта с ключом {}: {}", id, e.getMessage(), e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Возвращает итоговый TTL для ключей Redis.
+     */
+    private Duration getEffectiveTtl() {
+        return Duration.ofMillis(batchWindowDurationMs + EXTRA_TTL_MILLIS);
+    }
+}

--- a/src/main/java/com/neighbor/eventmosaic/processor/util/RedisKeysUtil.java
+++ b/src/main/java/com/neighbor/eventmosaic/processor/util/RedisKeysUtil.java
@@ -1,0 +1,48 @@
+package com.neighbor.eventmosaic.processor.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RedisKeysUtil {
+
+    // Префиксы для данных
+    private static final String EVENT_DATA_PREFIX = "data:event:";
+    private static final String MENTION_DATA_PREFIX = "data:mention:";
+    private static final String BATCH_EVENTS_KEY_PREFIX = "batch:events:"; // Множество ID событий
+    private static final String BATCH_MENTIONS_KEY_PREFIX = "batch:mentions:"; // Множество ID упоминаний
+
+    // Префиксы/ключи для состояния
+    private static final String BATCH_START_TIME_KEY_PREFIX = "batch:start:";
+    private static final String ACTIVE_BATCHES_KEY = "active:batches"; // Множество активных батчей
+    private static final String READY_BATCHES_KEY = "ready:batches";   // Множество готовых батчей
+
+    /* Данные */
+    public static String buildEventKey(String batchId, Long eventId) {
+        return EVENT_DATA_PREFIX + batchId + ":" + eventId;
+    }
+
+    public static String buildMentionKey(String batchId, String mentionId) {
+        return MENTION_DATA_PREFIX + batchId + ":" + mentionId;
+    }
+
+    public static String buildBatchEventsSetKey(String batchId) {
+        return BATCH_EVENTS_KEY_PREFIX + batchId;
+    }
+
+    public static String buildBatchMentionsSetKey(String batchId) {
+        return BATCH_MENTIONS_KEY_PREFIX + batchId;
+    }
+
+    /* Состояние */
+    public static String buildStartTimeKey(String batchId) {
+        return BATCH_START_TIME_KEY_PREFIX + batchId;
+    }
+
+    public static String activeBatchesSetKey() {
+        return ACTIVE_BATCHES_KEY;
+    }
+
+    public static String readyBatchesSetKey() {
+        return READY_BATCHES_KEY;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         isolation.level: read_committed                                                       # Уровень изоляции для чтения (только подтвержденные изменения)
+        spring.json.trusted.packages: com.neighbor.eventmosaic.library.common.dto             # Доверенные пакеты для десериализации
 
 
 server:
@@ -79,3 +80,8 @@ kafka:
     producer:
       processor-event: ${KAFKA_TOPIC_PROCESSOR_EVENT:gdelt-processor-event-topic}
       processor-mention: ${KAFKA_TOPIC_PROCESSOR_MENTION:gdelt-processor-mention-topic}
+
+# Настройки обработки батчей
+batch:
+  processing:
+    window-duration-ms: ${BATCH_PROCESSING_WINDOW_MS:60000}                                     # Время ожидания батча (1 минута по умолчанию)


### PR DESCRIPTION
 - реализация сервисов для управления состоянием через Redis
 - база для обработки событий и упоминаний
 - планировщики для периодической проверки и обработки данных
 - обновлены конфиги
 - добавлены классы для работы с Redis и Kafka
 - dto подтягиваем из общей либы (пока реализовано через composite build)
 - обновлен readme